### PR TITLE
Update example-extras.cfg

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -400,9 +400,11 @@
 #   prefix. Use this to define default values for g-code parameters.
 #   For example, if one were to define the macro MY_DELAY with gcode
 #   "G4 P{DELAY}" along with "default_parameter_DELAY = 50" then the
-#   command "MY_DELAY" would evaluate to "G4 P50". The default is to
-#   require that all parameters used in the gcode script be present in
-#   the command invoking the macro.
+#   command "MY_DELAY" would evaluate to "G4 P50". To override the
+#   default parameter when calling the command then using "MY_DELAY 
+#   DELAY=30" would evaluate to "G4 P30". The default is to require 
+#   that all parameters used in the gcode script be present in the 
+#   command invoking the macro.
 #variable_<name>:
 #   One may specify any number of options with a "variable_" prefix.
 #   The given variable name will be assigned the given value (parsed


### PR DESCRIPTION
Add description to default_parameter of g-code macro description of method to call macro with a non-default value.